### PR TITLE
Fix tree layout expansion

### DIFF
--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -178,11 +178,10 @@ class ImageEditor(QMainWindow):
         self.right_panel = QGroupBox("Слои")
         layout = QVBoxLayout()
         self.tree_widget = LayerTreeWidget()
-        layout.addWidget(self.tree_widget)
 
         scroll_area = QScrollArea()
-        scroll_area.setWidget(self.tree_widget)
         scroll_area.setWidgetResizable(True)
+        scroll_area.setWidget(self.tree_widget)
         layout.addWidget(scroll_area)
 
         self.tree_widget.itemClicked.connect(self.on_tree_item_clicked)


### PR DESCRIPTION
## Summary
- fix layout of the layer tree panel so widget isn't added twice

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2459b9708330a99d5bfb2642c516