### PR TITLE
Display original image after loading

### DIFF
--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -228,6 +228,11 @@ class ImageEditor(QMainWindow):
                 image = self.load_image(file_name)
                 if image is not None:
                     self.image_storage.images.append(image)
+                    self.display_image(image)
+                    self._active_image_index = 0
+                    self.tree_widget.add_root_item(
+                        "Оригинал", "Исходное изображение", 0, "original", image
+                    )
 
             # Обязательно инициализируем пустые списки для найденных объектов
             self.image_storage.class_object_image = [


### PR DESCRIPTION
## Summary
- Display opened image immediately and set it as the active image
- Add the original image to the layer tree
- Initialize object storage after tree population

## Testing
- `PYTHONPATH=. pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a68e95fa008323aca07df7b9b6746e