### PR TITLE
Add seedling part classification functionality

### DIFF
--- a/seeding/config.py
+++ b/seeding/config.py
@@ -13,5 +13,13 @@ DEFAULT_WEIGHTS_PATH = Path(
     )
 )
 
+# Путь к весам модели классификации. Можно задать переменной YOLO_CLASSIFY_WEIGHTS_PATH
+DEFAULT_CLASSIFY_WEIGHTS_PATH = Path(
+    os.getenv(
+        "YOLO_CLASSIFY_WEIGHTS_PATH",
+        str(PROJECT_ROOT / "results" / "exp_yolov8_klass_5" / "weights" / "best.pt"),
+    )
+)
+
 # Параметр поворота на 90 градусов: значение k для np.rot90
 ROTATE_K = 1

--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -26,8 +26,8 @@ from PyQt5.QtWidgets import (
 )
 from ultralytics import YOLO
 
-from seeding.config import ROTATE_K
-from seeding.models.data_models import ObjectImage, OriginalImage
+from seeding.config import ROTATE_K, DEFAULT_CLASSIFY_WEIGHTS_PATH
+from seeding.models.data_models import AllClassImage, ObjectImage, OriginalImage
 from seeding.utils import simple_nms
 from .tree_widget import LayerTreeWidget
 
@@ -118,6 +118,7 @@ class ImageEditor(QMainWindow):
         self.image_storage = OriginalImage()
         self.weights_path = weights_path
         self.model = YOLO(weights_path)
+        self.classify_model = None
 
         self.init_ui()
 
@@ -667,9 +668,92 @@ class ImageEditor(QMainWindow):
         self.display_image(image)
 
     def classify(self) -> None:
-        """Классифицирует найденные объекты (заглушка)."""
+        """Определяет для каждого сеянца части: flower, root и stem."""
         self._update_action_states()
-        logger.info("Классификация — пока не реализовано")
+
+        if not self.image_storage.class_object_image:
+            logger.warning("classify: Нет объектов для классификации")
+            return
+
+        if self.classify_model is None:
+            try:
+                self.classify_model = YOLO(str(DEFAULT_CLASSIFY_WEIGHTS_PATH))
+            except Exception as e:  # pragma: no cover - логирование
+                logger.error("Не удалось загрузить модель классификации: %s", e)
+                return
+
+        # Цвета для визуализации разных классов на кропе
+        color_map = {
+            "flower": (255, 0, 255),
+            "root": (0, 255, 0),
+            "stem": (255, 255, 0),
+        }
+
+        for img_idx, objects in enumerate(self.image_storage.class_object_image):
+            page_item = self.tree_widget.topLevelItem(img_idx)
+            for obj_idx, obj in enumerate(objects):
+                if not obj.image:
+                    continue
+                crop = obj.image[0]
+                try:
+                    result = self.classify_model(crop)[0]
+                except Exception as e:  # pragma: no cover - логирование
+                    logger.error("Ошибка классификации: %s", e)
+                    continue
+
+                boxes = result.boxes
+                if boxes is None or len(boxes) == 0:
+                    logger.debug("classify: не найден класс для объекта %s", obj_idx)
+                    continue
+
+                # Берём по одному лучшему боксу на каждый класс
+                best_by_class: dict[int, tuple[float, object]] = {}
+                for box in boxes:
+                    cls_id = int(box.cls.item())
+                    conf = float(box.conf.item())
+                    if cls_id not in best_by_class or conf > best_by_class[cls_id][0]:
+                        best_by_class[cls_id] = (conf, box)
+
+                parts: list[AllClassImage] = []
+                annotated_crop = crop.copy()
+
+                for cls_id, (conf, box) in best_by_class.items():
+                    x1, y1, x2, y2 = map(int, box.xyxy[0].tolist())
+                    part_img = crop[y1:y2, x1:x2].copy()
+                    class_name = self.classify_model.names.get(cls_id, str(cls_id))
+                    parts.append(
+                        AllClassImage(
+                            class_name=class_name, confidence=conf, image=part_img
+                        )
+                    )
+                    color = color_map.get(class_name, (0, 255, 0))
+                    cv2.rectangle(annotated_crop, (x1, y1), (x2, y2), color, 2)
+                    cv2.putText(
+                        annotated_crop,
+                        class_name,
+                        (x1, y1 - 5),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.5,
+                        color,
+                        1,
+                    )
+
+                obj.image[0] = annotated_crop
+                obj.image_all_class = parts
+
+                if page_item is not None:
+                    seeding_item = page_item.child(obj_idx)
+                    if seeding_item is not None:
+                        for i in reversed(range(seeding_item.childCount())):
+                            seeding_item.takeChild(i)
+                        for part in parts:
+                            self.tree_widget.add_class_item(
+                                seeding_item,
+                                part.class_name,
+                                f"Уверенность: {part.confidence:.2f}",
+                            )
+
+        logger.info("classify: завершено")
 
     def create_report(self) -> None:
         """Создаёт PDF-отчёт по текущим результатам детекции."""

--- a/seeding/ui/tree_widget.py
+++ b/seeding/ui/tree_widget.py
@@ -41,3 +41,12 @@ class LayerTreeWidget(QTreeWidget):
         )
         parent.addChild(child)
         return child
+
+    def add_class_item(self, parent, name, description):
+        """Добавляет подпункт классификации под выбранным сеянцем."""
+        child = QTreeWidgetItem(parent)
+        child.setText(0, name)
+        child.setText(1, description)
+        child.setData(0, Qt.UserRole, {"type": "class"})
+        parent.addChild(child)
+        return child


### PR DESCRIPTION
## Summary
- add config for classification model weights
- enable classification of seedling crops into flower, root, or stem
- show classification results as subitems in the layer tree
- detect all three seedling parts with bounding boxes for each crop

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a801aa8fa08323b04ccdac46947461