### PR TITLE
Switch to QGraphicsView for editable bounding boxes

### DIFF
--- a/seeding/ui/bbox_item.py
+++ b/seeding/ui/bbox_item.py
@@ -1,0 +1,95 @@
+"""Resizable rectangle item for interactive bounding boxes."""
+
+from PyQt5.QtCore import QRectF, Qt
+from PyQt5.QtGui import QPen
+from PyQt5.QtWidgets import QGraphicsItem, QGraphicsRectItem, QStyleOptionGraphicsItem, QWidget
+
+
+class BBoxItem(QGraphicsRectItem):
+    """QGraphicsRectItem with resize handles linked to ObjectImage."""
+
+    HANDLE_SIZE = 8.0
+
+    def __init__(self, rect: QRectF, obj, parent: QGraphicsItem | None = None):
+        super().__init__(rect, parent)
+        self.obj = obj
+        self.setPen(QPen(Qt.green, 2))
+        self.setFlags(
+            QGraphicsItem.ItemIsSelectable
+            | QGraphicsItem.ItemIsMovable
+            | QGraphicsItem.ItemSendsGeometryChanges
+        )
+        self._editable = False
+        self._handle = None
+        self._handles = {}
+        self._update_handles()
+
+    # ------------------------------------------------------------------
+    # handle utilities
+    def _update_handles(self) -> None:
+        """Recalculate handle rectangles."""
+        r = self.rect()
+        s = self.HANDLE_SIZE
+        self._handles = {
+            "tl": QRectF(r.x() - s / 2, r.y() - s / 2, s, s),
+            "tr": QRectF(r.right() - s / 2, r.y() - s / 2, s, s),
+            "bl": QRectF(r.x() - s / 2, r.bottom() - s / 2, s, s),
+            "br": QRectF(r.right() - s / 2, r.bottom() - s / 2, s, s),
+        }
+
+    def setEditable(self, state: bool) -> None:
+        """Enable or disable editing."""
+        self._editable = state
+        self.setFlag(QGraphicsItem.ItemIsMovable, state)
+        self.update()
+
+    # ------------------------------------------------------------------
+    # painting
+    def paint(self, painter, option: QStyleOptionGraphicsItem, widget: QWidget | None = None):
+        super().paint(painter, option, widget)
+        if self._editable:
+            painter.setBrush(Qt.white)
+            for handle_rect in self._handles.values():
+                painter.drawRect(handle_rect)
+
+    # ------------------------------------------------------------------
+    # mouse events
+    def mousePressEvent(self, event):
+        if self._editable:
+            for name, rect in self._handles.items():
+                if rect.contains(event.pos()):
+                    self._handle = name
+                    break
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._editable and self._handle:
+            r = self.rect()
+            pos = event.pos()
+            if self._handle == "tl":
+                r.setTopLeft(pos)
+            elif self._handle == "tr":
+                r.setTopRight(pos)
+            elif self._handle == "bl":
+                r.setBottomLeft(pos)
+            elif self._handle == "br":
+                r.setBottomRight(pos)
+            self.setRect(r)
+        else:
+            super().mouseMoveEvent(event)
+        if self._editable:
+            self._update_handles()
+            self.update_bbox()
+
+    def mouseReleaseEvent(self, event):
+        super().mouseReleaseEvent(event)
+        self._handle = None
+        if self._editable:
+            self._update_handles()
+            self.update_bbox()
+
+    # ------------------------------------------------------------------
+    def update_bbox(self) -> None:
+        """Update bbox in linked ObjectImage."""
+        r = self.rect().normalized()
+        self.obj.bbox = (int(r.left()), int(r.top()), int(r.right()), int(r.bottom()))

--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -6,18 +6,19 @@ import os
 import cv2
 import fitz
 import numpy as np
-from PyQt5.QtCore import QPoint, Qt, QThread, pyqtSignal
-from PyQt5.QtGui import QIcon, QImage, QPixmap
+from PyQt5.QtCore import QPoint, Qt, QThread, pyqtSignal, QRectF
+from PyQt5.QtGui import QIcon, QImage, QPixmap, QTransform
 
 from PyQt5.QtWidgets import (
     QAction,
     QFileDialog,
     QGroupBox,
-    QLabel,
+    QGraphicsPixmapItem,
+    QGraphicsScene,
+    QGraphicsView,
     QMainWindow,
     QScrollArea,
     QSplitter,
-
     QStyle,
     QToolBar,
     QProgressBar,
@@ -30,6 +31,7 @@ from seeding.config import ROTATE_K, DEFAULT_CLASSIFY_WEIGHTS_PATH
 from seeding.models.data_models import AllClassImage, ObjectImage, OriginalImage
 from seeding.utils import simple_nms
 from .tree_widget import LayerTreeWidget
+from .bbox_item import BBoxItem
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +154,7 @@ class ImageEditor(QMainWindow):
             self.find_all_seedlings_action,
             self.classify_action,
             self.report_action,
+            self.save_action,
         ):
             action.setEnabled(has_image)
 
@@ -225,6 +228,16 @@ class ImageEditor(QMainWindow):
         self.fit_action.triggered.connect(self.fit_to_window)
         toolbar.addAction(self.fit_action)
 
+        toolbar.addSeparator()
+
+        self.save_action = QAction(
+            style.standardIcon(QStyle.SP_DialogSaveButton),
+            "Сохранить изменения",
+            self,
+        )
+        self.save_action.triggered.connect(self.save_changes)
+        toolbar.addAction(self.save_action)
+
         self._update_action_states()
 
     def create_central_widget(self):
@@ -232,11 +245,14 @@ class ImageEditor(QMainWindow):
         self.scroll_area = DraggableScrollArea()
         self.scroll_area.setWidgetResizable(True)
 
-        self.image_label = QLabel("Тут будет изображение")
-        self.image_label.setAlignment(Qt.AlignCenter)
-        self.image_label.setStyleSheet("border: 1px dashed gray;")
+        self.graphics_view = QGraphicsView()
+        self.graphics_scene = QGraphicsScene(self)
+        self.graphics_view.setScene(self.graphics_scene)
+        self.image_item = QGraphicsPixmapItem()
+        self.graphics_scene.addItem(self.image_item)
+        self.rect_items = {}
 
-        self.scroll_area.setWidget(self.image_label)
+        self.scroll_area.setWidget(self.graphics_view)
 
         self.splitter = QSplitter(Qt.Horizontal)
         self.splitter.addWidget(self.scroll_area)
@@ -263,21 +279,40 @@ class ImageEditor(QMainWindow):
     def on_tree_item_clicked(self, item, column):
         """Обрабатывает выбор элемента в дереве слоёв."""
         item_data = item.data(0, Qt.UserRole)
-        if item_data:
-            if item_data["type"] in ("original", "pdf"):
-                idx = item_data["index"]
-                self._active_image_index = idx
-                self.display_image_with_boxes(idx)
-            elif item_data["type"] == "seeding":
-                parent_idx = item_data["parent_index"]
-                seed_idx = item_data["index"]
-                crop = self.image_storage.class_object_image[parent_idx][
-                    seed_idx
-                ].image[0]
-                self._active_image_index = parent_idx
-                self.display_image(crop)
-            else:
+        if not item_data:
+            return
+
+        if item_data["type"] in ("original", "pdf"):
+            idx = item_data["index"]
+            self._active_image_index = idx
+            self.display_image_with_boxes(idx)
+            return
+
+        if item_data["type"] == "seeding":
+            parent_idx = item_data["parent_index"]
+            seed_idx = item_data["index"]
+        elif item_data["type"] == "class":
+            parent = item.parent()
+            if parent is None:
                 return
+            parent_data = parent.data(0, Qt.UserRole)
+            if not parent_data or parent_data["type"] != "seeding":
+                return
+            parent_idx = parent_data["parent_index"]
+            seed_idx = parent_data["index"]
+        else:
+            return
+
+        self._active_image_index = parent_idx
+        self.display_image_with_boxes(parent_idx)
+        key = (parent_idx, seed_idx)
+        if hasattr(self, "rect_items") and key in self.rect_items:
+            for rect in self.rect_items.values():
+                rect.setEditable(False)
+                rect.setSelected(False)
+            rect_item = self.rect_items[key]
+            rect_item.setEditable(True)
+            rect_item.setSelected(True)
 
     def open_image(self) -> None:
         """Открывает диалог выбора файла и загружает изображение или PDF."""
@@ -386,6 +421,10 @@ class ImageEditor(QMainWindow):
         self._original_image = image
         self._original_pixmap = QPixmap.fromImage(q_image)
 
+        self.graphics_scene.clear()
+        self.image_item = self.graphics_scene.addPixmap(self._original_pixmap)
+        self.rect_items = {}
+
         scroll_size = self.scroll_area.viewport().size()
         ratio_w = scroll_size.width() / self._original_pixmap.width()
         ratio_h = scroll_size.height() / self._original_pixmap.height()
@@ -413,14 +452,15 @@ class ImageEditor(QMainWindow):
     def update_image_zoom(self) -> None:
         """Применяет текущий масштаб к изображению."""
         if hasattr(self, "_original_pixmap"):
-            pixmap = self._original_pixmap
-            new_width = max(1, int(pixmap.width() * self.zoom_factor))
-            new_height = max(1, int(pixmap.height() * self.zoom_factor))
-            scaled_pixmap = pixmap.scaled(
-                new_width, new_height, Qt.KeepAspectRatio, Qt.SmoothTransformation
+            transform = QTransform()
+            transform.scale(self.zoom_factor, self.zoom_factor)
+            self.graphics_view.setTransform(transform)
+            self.graphics_scene.setSceneRect(
+                0,
+                0,
+                self._original_pixmap.width(),
+                self._original_pixmap.height(),
             )
-            self.image_label.setPixmap(scaled_pixmap)
-            self.image_label.adjustSize()
 
     def rotate_image(self) -> None:
         """Поворачивает выбранное изображение или crop на 90 градусов."""
@@ -644,28 +684,33 @@ class ImageEditor(QMainWindow):
     def display_image_with_boxes(self, idx: int) -> None:
         """Отображает изображение с нанесёнными рамками объектов."""
         image = self.image_storage.images[idx].copy()
+        self.display_image(image)
         if (
             self.image_storage.class_object_image
             and len(self.image_storage.class_object_image) > idx
         ):
-            for i, obj in enumerate(
-                self.image_storage.class_object_image[idx], start=1
-            ):
+            for obj_idx, obj in enumerate(self.image_storage.class_object_image[idx]):
                 if obj.bbox:
                     x1, y1, x2, y2 = obj.bbox
-                    cv2.rectangle(
-                        image, (x1, y1), (x2, y2), color=(0, 255, 0), thickness=2
-                    )
-                    cv2.putText(
-                        image,
-                        f"{i}",  # Нумерация
-                        (x1, y1 - 5),
-                        cv2.FONT_HERSHEY_SIMPLEX,
-                        0.8,
-                        (0, 255, 0),
-                        2,
-                    )
-        self.display_image(image)
+                    rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                    rect_item = BBoxItem(rect, obj)
+                    rect_item.setEditable(False)
+                    self.graphics_scene.addItem(rect_item)
+                    self.rect_items[(idx, obj_idx)] = rect_item
+
+    def save_changes(self) -> None:
+        """Пересохраняет crop-изображения после изменения рамок."""
+        if not self.image_storage.images or not self.image_storage.class_object_image:
+            return
+        for img_idx, objects in enumerate(self.image_storage.class_object_image):
+            if img_idx >= len(self.image_storage.images):
+                continue
+            base_img = self.image_storage.images[img_idx]
+            for obj in objects:
+                if obj.bbox:
+                    x1, y1, x2, y2 = obj.bbox
+                    obj.image = [base_img[y1:y2, x1:x2].copy()]
+        logger.info("save_changes: обновлённые координаты сохранены")
 
     def classify(self) -> None:
         """Определяет для каждого сеянца класс: flower, root или stem."""
@@ -674,6 +719,9 @@ class ImageEditor(QMainWindow):
         if not self.image_storage.class_object_image:
             logger.warning("classify: Нет объектов для классификации")
             return
+
+        # Используем актуальные координаты перед классификацией
+        self.save_changes()
 
         if self.classify_model is None:
             try:


### PR DESCRIPTION
## Summary
- allow selecting classification results in the tree to highlight the corresponding seeding bbox
- refresh crops before classification so edits are considered

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a815466cf483238f4d71a6be720e04