### PR TITLE
Fix classification bounding boxes display

### DIFF
--- a/seeding/models/data_models.py
+++ b/seeding/models/data_models.py
@@ -20,6 +20,7 @@ class AllClassImage:
     class_name: str
     confidence: float
     image: Union[np.ndarray, Image.Image]
+    bbox: tuple | None = None  # (x1, y1, x2, y2) in original image coords
 
 
 @dataclass

--- a/seeding/report.py
+++ b/seeding/report.py
@@ -56,6 +56,11 @@ def _annotate_image(img: np.ndarray, objects: list[ObjectImage]) -> np.ndarray:
                 (0, 255, 0),
                 2,
             )
+        if obj.image_all_class:
+            for cls in obj.image_all_class:
+                if cls.bbox:
+                    x1, y1, x2, y2 = cls.bbox
+                    cv2.rectangle(annotated, (x1, y1), (x2, y2), (255, 0, 0), 2)
     return annotated
 
 

--- a/seeding/ui/bbox_item.py
+++ b/seeding/ui/bbox_item.py
@@ -10,10 +10,16 @@ class BBoxItem(QGraphicsRectItem):
 
     HANDLE_SIZE = 8.0
 
-    def __init__(self, rect: QRectF, obj, parent: QGraphicsItem | None = None):
+    def __init__(
+        self,
+        rect: QRectF,
+        obj,
+        parent: QGraphicsItem | None = None,
+        color=Qt.green,
+    ):
         super().__init__(rect, parent)
         self.obj = obj
-        self.setPen(QPen(Qt.green, 2))
+        self.setPen(QPen(color, 2))
         self.setFlags(
             QGraphicsItem.ItemIsSelectable
             | QGraphicsItem.ItemIsMovable

--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -684,6 +684,15 @@ class ImageEditor(QMainWindow):
                     self.graphics_scene.addItem(rect_item)
                     self.rect_items[(idx, obj_idx)] = rect_item
 
+                if obj.image_all_class:
+                    for cls_idx, cls_obj in enumerate(obj.image_all_class):
+                        if cls_obj.bbox:
+                            x1, y1, x2, y2 = cls_obj.bbox
+                            rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                            sub_item = BBoxItem(rect, cls_obj, color=Qt.red)
+                            sub_item.setEditable(False)
+                            self.graphics_scene.addItem(sub_item)
+
     def save_changes(self) -> None:
         """Пересохраняет crop-изображения после изменения рамок."""
         if not self.image_storage.images or not self.image_storage.class_object_image:
@@ -738,9 +747,21 @@ class ImageEditor(QMainWindow):
                 part_img = crop[y1:y2, x1:x2].copy()
                 class_name = self.classify_model.names.get(cls_id, str(cls_id))
 
+                if obj.bbox:
+                    gx1 = obj.bbox[0] + x1
+                    gy1 = obj.bbox[1] + y1
+                    gx2 = obj.bbox[0] + x2
+                    gy2 = obj.bbox[1] + y2
+                    global_bbox = (gx1, gy1, gx2, gy2)
+                else:
+                    global_bbox = (x1, y1, x2, y2)
+
                 obj.image_all_class = [
                     AllClassImage(
-                        class_name=class_name, confidence=conf, image=part_img
+                        class_name=class_name,
+                        confidence=conf,
+                        image=part_img,
+                        bbox=global_bbox,
                     )
                 ]
 
@@ -755,6 +776,8 @@ class ImageEditor(QMainWindow):
                             f"Уверенность: {conf:.2f}",
                         )
 
+        active_idx = getattr(self, "_active_image_index", 0)
+        self.display_image_with_boxes(active_idx)
         logger.info("classify: завершено")
 
     def create_report(self) -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
-from seeding.models.data_models import OriginalImage, ObjectImage
-from seeding.report import create_pdf_report
+from seeding.models.data_models import OriginalImage, ObjectImage, AllClassImage
+from seeding.report import create_pdf_report, _annotate_image
 
 def test_create_pdf_report(tmp_path):
     img = np.zeros((10, 10, 3), dtype=np.uint8)
@@ -10,3 +10,17 @@ def test_create_pdf_report(tmp_path):
     output = tmp_path / "report.pdf"
     create_pdf_report(data, str(output))
     assert output.is_file() and output.stat().st_size > 0
+
+
+def test_annotate_image_with_class_bbox():
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    cls = AllClassImage("part", 0.8, img, bbox=(2, 2, 4, 4))
+    obj = ObjectImage(
+        class_name="Seeding",
+        confidence=0.9,
+        image=[img],
+        bbox=(1, 1, 5, 5),
+        image_all_class=[cls],
+    )
+    annotated = _annotate_image(img, [obj])
+    assert (annotated[2, 2] == np.array([255, 0, 0])).all()


### PR DESCRIPTION
## Summary
- store bbox coordinates for subclass classifications
- allow colored bounding boxes and show class boxes in UI
- include subclass boxes in PDF reports
- add coverage for class bbox annotations

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a81a0ae40883239a302a68ac76fcd0