### PR TITLE
Store class boxes relative to seedling crop

### DIFF
--- a/seeding/models/data_models.py
+++ b/seeding/models/data_models.py
@@ -20,7 +20,7 @@ class AllClassImage:
     class_name: str
     confidence: float
     image: Union[np.ndarray, Image.Image]
-    bbox: tuple | None = None  # (x1, y1, x2, y2) in original image coords
+    bbox: tuple | None = None  # (x1, y1, x2, y2) относит. к кропу сеянца
 
 
 @dataclass

--- a/seeding/report.py
+++ b/seeding/report.py
@@ -24,6 +24,7 @@ from reportlab.platypus import (
 )
 
 from seeding.models.data_models import ObjectImage, OriginalImage
+from seeding.utils import rotate_bbox
 
 
 def _np_to_pil(img: np.ndarray) -> Image.Image:
@@ -56,10 +57,22 @@ def _annotate_image(img: np.ndarray, objects: list[ObjectImage]) -> np.ndarray:
                 (0, 255, 0),
                 2,
             )
-        if obj.image_all_class:
+        if obj.image_all_class and obj.bbox:
+            k = getattr(obj, "rotation_k", 0) % 4
+            h_rot, w_rot = obj.image[0].shape[:2] if obj.image else (0, 0)
             for cls in obj.image_all_class:
                 if cls.bbox:
-                    x1, y1, x2, y2 = cls.bbox
+                    lx1, ly1, lx2, ly2 = cls.bbox
+                    if k and h_rot and w_rot:
+                        ux1, uy1, ux2, uy2 = rotate_bbox(
+                            lx1, ly1, lx2, ly2, w_rot, h_rot, (-k) % 4
+                        )
+                    else:
+                        ux1, uy1, ux2, uy2 = lx1, ly1, lx2, ly2
+                    x1 = obj.bbox[0] + ux1
+                    y1 = obj.bbox[1] + uy1
+                    x2 = obj.bbox[0] + ux2
+                    y2 = obj.bbox[1] + uy2
                     cv2.rectangle(annotated, (x1, y1), (x2, y2), (255, 0, 0), 2)
     return annotated
 

--- a/seeding/ui/main_window.py
+++ b/seeding/ui/main_window.py
@@ -29,7 +29,7 @@ from ultralytics import YOLO
 
 from seeding.config import ROTATE_K, DEFAULT_CLASSIFY_WEIGHTS_PATH
 from seeding.models.data_models import AllClassImage, ObjectImage, OriginalImage
-from seeding.utils import simple_nms
+from seeding.utils import simple_nms, rotate_bbox
 from .tree_widget import LayerTreeWidget
 from .bbox_item import BBoxItem
 
@@ -704,44 +704,12 @@ class ImageEditor(QMainWindow):
         crop_img = obj.image[0].copy()
         self.display_image(crop_img)
 
-        x_off, y_off = 0, 0
-        if obj.bbox:
-            x_off, y_off = obj.bbox[0], obj.bbox[1]
-
         if obj.image_all_class:
             for cls_idx, cls_obj in enumerate(obj.image_all_class):
                 if cls_obj.bbox:
-                    gx1, gy1, gx2, gy2 = cls_obj.bbox
-                    lx1, ly1 = gx1 - x_off, gy1 - y_off
-                    lx2, ly2 = gx2 - x_off, gy2 - y_off
-
-                    rotation_k = getattr(obj, "rotation_k", 0) % 4
-                    if rotation_k:
-                        w = obj.bbox[2] - obj.bbox[0]
-                        h = obj.bbox[3] - obj.bbox[1]
-                        coords = [
-                            (lx1, ly1),
-                            (lx2, ly1),
-                            (lx1, ly2),
-                            (lx2, ly2),
-                        ]
-                        if rotation_k == 1:
-                            points = [(y, w - 1 - x) for x, y in coords]
-                        elif rotation_k == 2:
-                            points = [(w - 1 - x, h - 1 - y) for x, y in coords]
-                        elif rotation_k == 3:
-                            points = [(h - 1 - y, x) for x, y in coords]
-                        else:
-                            points = coords
-                        xs = [p[0] for p in points]
-                        ys = [p[1] for p in points]
-                        lx1, lx2 = min(xs), max(xs)
-                        ly1, ly2 = min(ys), max(ys)
-
+                    lx1, ly1, lx2, ly2 = cls_obj.bbox
                     rect = QRectF(lx1, ly1, lx2 - lx1, ly2 - ly1)
-                    rect_item = BBoxItem(
-                        rect, cls_obj, color=Qt.red, offset=(x_off, y_off)
-                    )
+                    rect_item = BBoxItem(rect, cls_obj, color=Qt.red)
                     rect_item.setEditable(True)
                     self.graphics_scene.addItem(rect_item)
                     self.rect_items[(parent_idx, seed_idx, cls_idx)] = rect_item
@@ -783,12 +751,27 @@ class ImageEditor(QMainWindow):
                         crop = np.rot90(crop, k=obj.rotation_k)
                     obj.image = [crop]
                 if obj.image_all_class:
+                    k = getattr(obj, "rotation_k", 0) % 4
+                    h_rot, w_rot = obj.image[0].shape[:2] if obj.image else (0, 0)
                     for cls in obj.image_all_class:
                         if cls.bbox:
-                            x1, y1, x2, y2 = cls.bbox
-                            part = base_img[y1:y2, x1:x2].copy()
-                            if getattr(obj, "rotation_k", 0):
-                                part = np.rot90(part, k=obj.rotation_k)
+                            lx1, ly1, lx2, ly2 = cls.bbox
+                            if k and h_rot and w_rot:
+                                ux1, uy1, ux2, uy2 = rotate_bbox(
+                                    lx1, ly1, lx2, ly2, w_rot, h_rot, (-k) % 4
+                                )
+                            else:
+                                ux1, uy1, ux2, uy2 = lx1, ly1, lx2, ly2
+                            if obj.bbox:
+                                gx1 = obj.bbox[0] + ux1
+                                gy1 = obj.bbox[1] + uy1
+                                gx2 = obj.bbox[0] + ux2
+                                gy2 = obj.bbox[1] + uy2
+                            else:
+                                gx1, gy1, gx2, gy2 = ux1, uy1, ux2, uy2
+                            part = base_img[gy1:gy2, gx1:gx2].copy()
+                            if k:
+                                part = np.rot90(part, k=k)
                             cls.image = part
         logger.info("save_changes: обновлённые координаты сохранены")
 
@@ -838,21 +821,18 @@ class ImageEditor(QMainWindow):
                     part_img = np.rot90(part_img, k=rotation_k)
                 class_name = self.classify_model.names.get(cls_id, str(cls_id))
 
-                if obj.bbox:
-                    gx1 = obj.bbox[0] + x1
-                    gy1 = obj.bbox[1] + y1
-                    gx2 = obj.bbox[0] + x2
-                    gy2 = obj.bbox[1] + y2
-                    global_bbox = (gx1, gy1, gx2, gy2)
-                else:
-                    global_bbox = (x1, y1, x2, y2)
+                w, h = crop_for_model.shape[1], crop_for_model.shape[0]
+                lx1, ly1, lx2, ly2 = rotate_bbox(
+                    x1, y1, x2, y2, w, h, rotation_k
+                )
+                local_bbox = (lx1, ly1, lx2, ly2)
 
                 obj.image_all_class = [
                     AllClassImage(
                         class_name=class_name,
                         confidence=conf,
                         image=part_img,
-                        bbox=global_bbox,
+                        bbox=local_bbox,
                     )
                 ]
 

--- a/seeding/utils.py
+++ b/seeding/utils.py
@@ -42,3 +42,30 @@ def simple_nms(boxes, scores, iou_threshold=0.4):
         order = order[inds + 1]
     logger.debug("simple_nms: после NMS осталось %s боксов", len(keep))
     return keep
+
+
+def rotate_bbox(x1, y1, x2, y2, w, h, k):
+    """Повернуть прямоугольник на ``k``·90° против часовой стрелки.
+
+    Args:
+        x1, y1, x2, y2: Координаты прямоугольника в исходной системе.
+        w, h: Ширина и высота исходного изображения.
+        k: Количество поворотов против часовой стрелки (0-3).
+
+    Returns:
+        tuple[int, int, int, int]: Координаты прямоугольника после поворота.
+    """
+    k = k % 4
+    coords = [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
+    if k == 1:
+        pts = [(y, w - 1 - x) for x, y in coords]
+    elif k == 2:
+        pts = [(w - 1 - x, h - 1 - y) for x, y in coords]
+    elif k == 3:
+        pts = [(h - 1 - y, x) for x, y in coords]
+    else:
+        pts = coords
+
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    return int(min(xs)), int(min(ys)), int(max(xs)), int(max(ys))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -14,7 +14,7 @@ def test_create_pdf_report(tmp_path):
 
 def test_annotate_image_with_class_bbox():
     img = np.zeros((10, 10, 3), dtype=np.uint8)
-    cls = AllClassImage("part", 0.8, img, bbox=(2, 2, 4, 4))
+    cls = AllClassImage("part", 0.8, img, bbox=(1, 1, 3, 3))
     obj = ObjectImage(
         class_name="Seeding",
         confidence=0.9,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from seeding.utils import simple_nms
+from seeding.utils import simple_nms, rotate_bbox
 
 
 def test_simple_nms_basic():
@@ -7,3 +7,13 @@ def test_simple_nms_basic():
     scores = [0.9, 0.8, 0.7]
     keep = simple_nms(boxes, scores, iou_threshold=0.5)
     assert keep == [0, 2]
+
+
+def test_rotate_bbox_roundtrip():
+    w, h = 10, 6
+    box = (1, 2, 7, 5)
+    for k in range(4):
+        rx1, ry1, rx2, ry2 = rotate_bbox(*box, w, h, k)
+        w_rot, h_rot = (h, w) if k % 2 else (w, h)
+        bx1, by1, bx2, by2 = rotate_bbox(rx1, ry1, rx2, ry2, w_rot, h_rot, (-k) % 4)
+        assert (bx1, by1, bx2, by2) == box


### PR DESCRIPTION
## Summary
- keep classification bbox coordinates relative to seedling crop
- rotate and translate boxes when saving or creating reports
- add rotate_bbox helper and tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a833fd61648323881878f618b8eccb